### PR TITLE
Fix sizes for screens 360px and lower

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ const YSmartCaptcha = {
         return h('div', {
           style: 'height: 100px;',
           id: this.widgetId,
-          class: 'smart-captcha',
           'data-sitekey': options.siteKey
         });
       },


### PR DESCRIPTION
Убран лишний класс, который в исходном скрипте капчи содержал всего 2 css-стиля:
![image](https://github.com/user-attachments/assets/0f4a4092-bb64-4ea8-8605-a27a04fb1cde)
Height уже указывается для div-а инлайном, а min-width мешает адаптивности для самых маленьких экранчиков :)
1-й скриншот ниже - как было, 2-й скриншот - как стало:
![image](https://github.com/user-attachments/assets/39dc080b-4346-4cd5-a661-548747a56c81)
![image](https://github.com/user-attachments/assets/24f41544-8d14-473c-a204-a68c76ce5477)
